### PR TITLE
Add keyboard control

### DIFF
--- a/sample/.demoit/js/demoit.js
+++ b/sample/.demoit/js/demoit.js
@@ -98,7 +98,7 @@ customElements.define('source-code', class extends HTMLElement {
     border-bottom: 2px solid #cbcbcb;
     border-radius: 0.4em 0.4em 0 0;
 }
-    
+
 .browser i {
     display: inline-block;
     height: 0.7em;
@@ -158,7 +158,7 @@ customElements.define('source-code', class extends HTMLElement {
     height: 42px;
     text-align: left;
     border-bottom: 1.5px solid rgb(236, 236, 236);
-    overflow: hidden; 
+    overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap
 }
@@ -289,7 +289,7 @@ iframe {
     border-bottom: 2px solid #cbcbcb;
     border-radius: 0.4em 0.4em 0 0;
 }
- 
+
 .browser i {
     display: inline-block;
     height: 0.7em;
@@ -479,7 +479,7 @@ iframe {
     font-size: 1.5em;
     text-decoration: none;
 }
-    
+
 .browser i {
     display: inline-block;
     height: 0.7em;

--- a/sample/.demoit/js/demoit.js
+++ b/sample/.demoit/js/demoit.js
@@ -14,6 +14,31 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Move the page to the next slide
+function next() {
+    window.location.href = NextURL;
+}
+
+// Move the page to the previous slide
+function prev() {
+    window.location.href = PrevURL;
+}
+
+// Capture keydown events, and change slides accordingly
+document.addEventListener("keydown", event => {
+    switch (event.key) {
+        case "ArrowRight":
+        case " ":
+            next();
+            break;
+        case "ArrowLeft":
+            prev();
+            break;
+        default:
+            return;
+    }
+});
+
 // Maximize a "window".
 function maximize(w) {
     if (w.savedStyle != undefined) {

--- a/templates/index.go
+++ b/templates/index.go
@@ -24,12 +24,16 @@ func Index(content []byte) string {
         <meta charset="utf-8">
         <title>Demo</title>
         <link rel="stylesheet" href="/style.css">
+        <script>
+            const NextURL = '{{ .NextURL }}';
+            const PrevURL = '{{ .PrevURL }}';
+        </script>
       </head>
       <body>
       <div id="top">` + string(content) + `
       <div id="nav">
-        <a class="{{ if not .PrevURL }}disabled{{ end }}" onclick="window.location.href='{{ .PrevURL }}';">&lt;</a>
-        <a class="{{ if not .NextURL }}disabled{{ end }}" onclick="window.location.href='{{ .NextURL }}';">&gt;</a>
+        <a class="{{ if not .PrevURL }}disabled{{ end }}" onclick="prev()">&lt;</a>
+        <a class="{{ if not .NextURL }}disabled{{ end }}" onclick="next()">&gt;</a>
       </div>
       </div>
       <div id="progression" style="width: calc(100vw * {{ .CurrentStep }} / {{ .StepCount }})"></div>


### PR DESCRIPTION
This PR adds the ability to switch between slides with <kbd>←</kbd>, <kbd>→</kbd> and <kbd>Space</kbd>.

Elements that capture input (such as the shell) still get focus before the main document, so this doesn't interfere with any live input. (On slides that have live input, you'll need to click the arrows to navigate, or click outside the input-capturing area to change focus, and then use the keyboard.)