### PR TITLE
Imported flags package in handlers/shell.go

### DIFF
--- a/handlers/shell.go
+++ b/handlers/shell.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/dgageot/demoit/files"
+	"github.com/dgageot/demoit/flags"
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
 )


### PR DESCRIPTION
## Summary
- Failed `go get` due to `flags` package not being imported in `handlers/shell.go` was fixed.

## Types of changes
- Bug Fix

## Related issue
- https://github.com/dgageot/demoit/issues/16

## Checklist
- [x] Implementation
- [ ] Black-box Test
- [ ] Unit Test
