### PR TITLE
Fix Welcome message, when -host is used (not localhost).

### DIFF
--- a/main.go
+++ b/main.go
@@ -72,7 +72,7 @@ func startFileWatch(root string) {
 func startWebServer(r http.Handler) {
 	addr := flags.WebServerAddress()
 
-	log.Printf("Welcome to DemoIt. Please, open %s", addr)
+	log.Printf("Welcome to DemoIt. Please, open %s", "http://"+addr)
 	if !*flags.DevMode {
 		log.Printf("\"Dev Mode\" to live reload your slides can be enabled with '--dev'")
 	}

--- a/main.go
+++ b/main.go
@@ -71,9 +71,8 @@ func startFileWatch(root string) {
 
 func startWebServer(r http.Handler) {
 	addr := flags.WebServerAddress()
-	port := *flags.WebServerPort
 
-	log.Printf("Welcome to DemoIt. Please, open http://localhost:%d", port)
+	log.Printf("Welcome to DemoIt. Please, open %s", addr)
 	if !*flags.DevMode {
 		log.Printf("\"Dev Mode\" to live reload your slides can be enabled with '--dev'")
 	}


### PR DESCRIPTION
Note that the "http://" prefix won't be displayed.