### PR TITLE
Fix panic when hashing a missing file (see func comment).

### DIFF
--- a/templates/index.go
+++ b/templates/index.go
@@ -44,6 +44,9 @@ func Index(content []byte) string {
 
 // Ignore errors and return empty string if an error occurs.
 func hash(path string) string {
-	h, _ := files.Sha256(path)
+	h, err := files.Sha256(path)
+	if err != nil {
+		return ""
+	}
 	return h[:10]
 }


### PR DESCRIPTION
`style.css` and `demoit.js` can be regarded as "mandatory", but `hash` is not supposed to be the right place to panic about it.