### PR TITLE
Fail fast if folder ".demoit" doesn't exist.

### DIFF
--- a/handlers/step.go
+++ b/handlers/step.go
@@ -18,10 +18,12 @@ package handlers
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"html/template"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strconv"
 
@@ -134,4 +136,19 @@ func readSteps(folder string) ([]Page, error) {
 func VerifyStepsFile() error {
 	_, err := readSteps(files.Root)
 	return err
+}
+
+// VerifyResourceFolder returns non-nil error if it can't find folder .demoit
+func VerifyResourceFolder() error {
+	info, err := os.Stat(".demoit")
+	if os.IsNotExist(err) {
+		return errors.New(".demoit doesn't exist")
+	}
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() {
+		return errors.New(".demoit is not a folder")
+	}
+	return nil
 }

--- a/main.go
+++ b/main.go
@@ -58,6 +58,11 @@ func main() {
 		log.Fatalln(err)
 	}
 
+	// Fail fast, in case we can't find the resource folder ".demoit"
+	if err := handlers.VerifyResourceFolder(); err != nil {
+		log.Fatalf("mandatory resource folder \".demoit\": %v", err)
+	}
+
 	go startWebServer(r)
 	if *flags.DevMode {
 		go startFileWatch(files.Root)


### PR DESCRIPTION
There is no need to start the server when folder `.demoit` doesn't exist, because:
- without it, there is no slide next/previous navigation
- without it, it is not possible to use `<web-term>` and `<web-browser>`
- a new user may be aware of `demoit.html` (prominent) but not if `.demoit` (hidden). We should inform this user that they're missing something mandatory.