### PR TITLE
issues/41 Fix folder check: take files.Root into account.

### DIFF
--- a/handlers/step.go
+++ b/handlers/step.go
@@ -140,7 +140,8 @@ func VerifyStepsFile() error {
 
 // VerifyResourceFolder returns non-nil error if it can't find folder .demoit
 func VerifyResourceFolder() error {
-	info, err := os.Stat(".demoit")
+	folderpath := filepath.Join(files.Root, ".demoit")
+	info, err := os.Stat(folderpath)
 	if os.IsNotExist(err) {
 		return errors.New(".demoit doesn't exist")
 	}


### PR DESCRIPTION
I introduced the regression #41, sorry about that. Here is the fix.