### PR TITLE
Fix vs-code

### DIFF
--- a/vscode/server.go
+++ b/vscode/server.go
@@ -64,7 +64,7 @@ func startVsCodeServer(ctx context.Context) error {
 	body, err := client.ContainerCreate(ctx, &containertypes.Config{
 		Image: "codercom/code-server:3.4.1",
 		User:  fmt.Sprintf("%s:%s", user.Uid, user.Gid),
-		Cmd:   []string{"--auth=none", "--disable-updates", "--disable-telemetry"},
+		Cmd:   []string{"--auth=none", "--disable-telemetry"},
 		ExposedPorts: nat.PortSet{
 			nat.Port("8080/tcp"): struct{}{},
 		},

--- a/vscode/server.go
+++ b/vscode/server.go
@@ -62,7 +62,7 @@ func startVsCodeServer(ctx context.Context) error {
 	_ = client.ContainerRemove(ctx, "demoit-vscode", types.ContainerRemoveOptions{Force: true})
 
 	body, err := client.ContainerCreate(ctx, &containertypes.Config{
-		Image: "codercom/code-server",
+		Image: "codercom/code-server:3.4.1",
 		User:  fmt.Sprintf("%s:%s", user.Uid, user.Gid),
 		Cmd:   []string{"--auth=none", "--disable-updates", "--disable-telemetry"},
 		ExposedPorts: nat.PortSet{


### PR DESCRIPTION
This patch fixes vs-code server docker invocation by;

- Removing deprecated cli option for the latest container image.
- Locking **codercom/code-server** docker image to **3.4.1**
